### PR TITLE
Fix tracking storage get() returning array instead of Collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `simplestats-client` will be documented in this file.
 
+## Unreleased
+
+### What's changed
+
+* Fixed `SessionTrackingStorage::get()` and `CacheTrackingStorage::get()` returning an array (and triggering a `TypeError`) when stored attribution data is read back. Both now always wrap the value in a `Collection`.
+
 ## v5.0.1 - 2026-07-14
 
 ### What's changed

--- a/src/Storage/CacheTrackingStorage.php
+++ b/src/Storage/CacheTrackingStorage.php
@@ -20,7 +20,8 @@ class CacheTrackingStorage implements TrackingStorage
             return collect();
         }
 
-        return Cache::get(self::CACHE_KEY_PREFIX.$identifier) ?? collect();
+        // Cache may return an array (e.g. after JSON serialization), so always wrap.
+        return collect(Cache::get(self::CACHE_KEY_PREFIX.$identifier) ?? []);
     }
 
     public function has(string $identifier): bool

--- a/src/Storage/SessionTrackingStorage.php
+++ b/src/Storage/SessionTrackingStorage.php
@@ -15,7 +15,8 @@ class SessionTrackingStorage implements TrackingStorage
 
     public function get(?string $identifier): Collection
     {
-        return session(self::SESSION_KEY) ?? collect();
+        // Session drivers serialize Collections as arrays, so always wrap.
+        return collect(session(self::SESSION_KEY) ?? []);
     }
 
     public function has(string $identifier): bool

--- a/tests/Storage/TrackingStorageTest.php
+++ b/tests/Storage/TrackingStorageTest.php
@@ -1,0 +1,73 @@
+<?php
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
+use SimpleStatsIo\LaravelClient\Storage\CacheTrackingStorage;
+use SimpleStatsIo\LaravelClient\Storage\SessionTrackingStorage;
+
+it('returns a collection from session storage when the session holds an array', function () {
+    $storage = new SessionTrackingStorage;
+
+    session([SessionTrackingStorage::SESSION_KEY => [
+        'source' => 'google',
+        'ip' => '1.2.3.4',
+    ]]);
+
+    $result = $storage->get('visitor-hash');
+
+    expect($result)->toBeInstanceOf(Collection::class)
+        ->and($result->get('source'))->toBe('google')
+        ->and($result->get('ip'))->toBe('1.2.3.4');
+});
+
+it('returns an empty collection from session storage when nothing is stored', function () {
+    $storage = new SessionTrackingStorage;
+
+    expect($storage->get('visitor-hash'))->toBeInstanceOf(Collection::class)
+        ->and($storage->get('visitor-hash'))->toBeEmpty();
+});
+
+it('returns a collection from session storage after putting a collection', function () {
+    $storage = new SessionTrackingStorage;
+
+    $storage->put('visitor-hash', collect([
+        'source' => 'newsletter',
+        'page' => '/pricing',
+    ]));
+
+    $result = $storage->get('visitor-hash');
+
+    expect($result)->toBeInstanceOf(Collection::class)
+        ->and($result->get('source'))->toBe('newsletter')
+        ->and($result->get('page'))->toBe('/pricing');
+});
+
+it('returns a collection from cache storage when the cache holds an array', function () {
+    $storage = new CacheTrackingStorage;
+    $identifier = 'visitor-hash';
+
+    Cache::put(CacheTrackingStorage::CACHE_KEY_PREFIX.$identifier, [
+        'source' => 'google',
+        'ip' => '1.2.3.4',
+    ], now()->endOfDay());
+
+    $result = $storage->get($identifier);
+
+    expect($result)->toBeInstanceOf(Collection::class)
+        ->and($result->get('source'))->toBe('google')
+        ->and($result->get('ip'))->toBe('1.2.3.4');
+});
+
+it('returns an empty collection from cache storage when nothing is stored', function () {
+    $storage = new CacheTrackingStorage;
+
+    expect($storage->get('missing'))->toBeInstanceOf(Collection::class)
+        ->and($storage->get('missing'))->toBeEmpty();
+});
+
+it('returns an empty collection from cache storage when the identifier is empty', function () {
+    $storage = new CacheTrackingStorage;
+
+    expect($storage->get(null))->toBeInstanceOf(Collection::class)->toBeEmpty()
+        ->and($storage->get(''))->toBeInstanceOf(Collection::class)->toBeEmpty();
+});


### PR DESCRIPTION
## Summary
- `SessionTrackingStorage::get()` and `CacheTrackingStorage::get()` now always wrap the stored value in `collect()`, matching their `Collection` return type.
- Session/cache drivers deserialize stored Collections as arrays, so reading attribution back (e.g. on login) could throw: `Return value must be of type Illuminate\Support\Collection, array returned`.
- Adds Pest coverage for both storage drivers, including the array-from-session case.

## Test plan
- [x] `vendor/bin/pest tests/Storage/TrackingStorageTest.php`
- [ ] Confirm login / registration tracking no longer TypeErrors when session already holds attribution data


Made with [Cursor](https://cursor.com)